### PR TITLE
subject_text and body_text variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A [Concourse CI](http://concourse.ci) resource to send emails.
 ## Source Configuration
 
 * `from`: *Required*. The email address of the sender as a string.
+* `variable_start_string`: *Optional*. The jinja2 variable_start_string environment option. Default: `{{`
+* `variable_end_string`: *Optional*. The jinja2 variable_end_string environment option. Default: `}}`
 
 ### Example
 
@@ -59,15 +61,17 @@ be rendered into the template. Additionally to the variables from the `vars`-fil
 be used in the template (e.g.: ``BUILD_ID``). By default (if the MIME subtype is "html"), the CSS styles will be
 inlined to the HTML. If you don't want that, you can set the `inline_css` parameter to `False`.
 If you want to use jinja-template in `subject_text` or `body_text` you need to define the content as a multiline text, otherwise a syntax error will be reported for malformed yaml.
+Also note that the concourse variable substitution uses `{{}}` as tokens which conflicts with jinja2 template variable substitution. You will therefore need to change `variable_start_string`
+and `variable_end_string` in your resource definition, for example setting them to `{(` and `)}`.
 
 ``` yaml
 - put: send-email
   params:
     to: [recipient@example.com]
     subject_text: |
-      {% block BUILD_PIPELINE_NAME %}{% endblock %}:{% block BUILD_JOB_NAME %}{% endblock %} failed
+      {(BUILD_PIPELINE_NAME)}:{(BUILD_JOB_NAME)} failed
     body_text: |
-      {% block BUILD_PIPELINE_NAME %}{% endblock %}:{% block BUILD_JOB_NAME %}{% endblock %} failed
+      {(BUILD_PIPELINE_NAME)}:{(BUILD_JOB_NAME)} failed
 ```
 
 A more elaborate usage example would look like this:

--- a/opt/resource/out
+++ b/opt/resource/out
@@ -13,7 +13,7 @@ import sys
 import time
 
 from inlinestyler.utils import inline_css
-from jinja2 import Template
+from jinja2 import Environment
 
 from common import get_payload
 
@@ -21,10 +21,13 @@ from common import get_payload
 def put(src):
     print("Using dir {}".format(src), file=sys.stderr)
     payload = get_payload()
+    variable_start_string = get_value_from_payload(payload, "source", "variable_start_string", default="{{", optional=True)
+    variable_end_string = get_value_from_payload(payload, "source", "variable_end_string", default="}}", optional=True)
+    env = Environment(variable_start_string=variable_start_string, variable_end_string=variable_end_string)
     template_vars = get_template_vars(src, payload)
     mime_subtype = get_mime_subtype(payload)
-    subject = get_subject(src, payload, template_vars)
-    body = get_message(src, payload, template_vars)
+    subject = get_subject(env, src, payload, template_vars)
+    body = get_message(env, src, payload, template_vars)
 
     if mime_subtype == 'html':
         message = MIMEMultipart('alternative')
@@ -70,16 +73,16 @@ def get_mime_subtype(payload):
     return get_value_from_payload(payload, 'params', 'type', default='html', optional=True)
 
 
-def get_subject(src, payload, template_vars):
+def get_subject(env, src, payload, template_vars):
     subject = get_value_from_payload(payload, 'params', 'subject_text', optional=True)
     if not subject:
         fname = get_value_from_payload(payload, 'params', 'subject')
         with open(os.path.join(src, fname)) as fp:
             subject = fp.read()
-    return Template(subject).render(template_vars)
+    return env.from_string(subject).render(template_vars)
 
 
-def get_message(src, payload, template_vars):
+def get_message(env, src, payload, template_vars):
     message = get_value_from_payload(payload, 'params', 'body_text', optional=True)
     if not message:
         fname = get_value_from_payload(payload, 'params', 'body')
@@ -88,7 +91,7 @@ def get_message(src, payload, template_vars):
 
     inline = get_value_from_payload(payload, 'params', 'inline_css', default=True, optional=True)
     mime_subtype = get_mime_subtype(payload)
-    message = Template(message).render(template_vars)
+    message = env.from_string(message).render(template_vars)
 
     if mime_subtype == 'html' and inline:
         message = inline_css(message)


### PR DESCRIPTION
I found that the way I used to do variable substitution before is no longer valid. I have added to source params variable_start_string and variable_end_string that can be used to avoid the conflict between concourse and jinja variable substitution by configuring jinja to use another start and end token such as {( )} instead of {{ }}

I have updated the documentation accordingly.

Solves #6 