### PR TITLE
Allow files to be attached to the e-mail

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Sending an email message:
 * `vars`: _(optional)_ A path to a JSON-file holding template vars.
 * `type`: _(optional)_ The MIME subtype (defaults to `"html"`)
 * `inline_css`: _(optional)_ Inline CSS to style attributes in HTML.
+* `attachments`: A list of file names that will be attached to the email. Attachments only work if `type` is `"html"`.
 
 `subject|subject_text` and `body|body_text` can both either be plain text, html or a [jinja](http://jinja.pocoo.org/docs/dev/)-template.
 In the latter case you can specify an additional file (`vars`) for holding template variables that should

--- a/opt/resource/out
+++ b/opt/resource/out
@@ -2,6 +2,8 @@
 
 from datetime import datetime
 from contextlib import contextmanager
+from email import encoders
+from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from html2text import html2text
@@ -36,6 +38,7 @@ def put(src):
     message['Subject'] = subject
     message['From'] = get_sender(payload)
     message['To'] = ', '.join(get_recipients(src, payload))
+    add_attachments(message, payload)
 
     with postfix():
         with SMTP('localhost') as smtp:
@@ -64,6 +67,21 @@ def get_recipients(src, payload):
     if not isinstance(recipients, list):
         raise ValueError("The recipients parameter has to be a list!")
     return recipients
+
+
+def add_attachments(message, payload):
+    file_names = get_value_from_payload(payload, 'params', 'attachments', default=[], optional=True)
+    for file_name in file_names:
+        message.attach(get_attachment(file_name))
+
+
+def get_attachment(file_name):
+    attachment = MIMEBase('application', 'octet-stream')
+    with open(file_name) as fp:
+        attachment.set_payload(fp.read())
+    encoders.encode_base64(attachment)
+    attachment.add_header('Content-Disposition', 'attachment', filename=file_name)
+    return attachment
 
 
 def get_mime_subtype(payload):


### PR DESCRIPTION
As far as I can tell, none of the other [Concourse resources types for sending e-mail](https://concourse.ci/resource-types.html) support attachments.