### PR TITLE
add suport to wildcard in attachments and multiple mime types

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Sending an email message:
 * `vars`: _(optional)_ A path to a JSON-file holding template vars.
 * `type`: _(optional)_ The MIME subtype (defaults to `"html"`)
 * `inline_css`: _(optional)_ Inline CSS to style attributes in HTML.
-* `attachments`: A list of file names that will be attached to the email. Attachments only work if `type` is `"html"`.
+* `attachments`: A list of file names that will be attached to the email. Attachments only work if `type` is `"html"`, wildcards (`*`) are supported, ex: `your-attachment-*.zip`.
 
 `subject|subject_text` and `body|body_text` can both either be plain text, html or a [jinja](http://jinja.pocoo.org/docs/dev/)-template.
 In the latter case you can specify an additional file (`vars`) for holding template variables that should

--- a/opt/resource/out
+++ b/opt/resource/out
@@ -4,8 +4,10 @@ from datetime import datetime
 from contextlib import contextmanager
 from email import encoders
 from email.mime.base import MIMEBase
-from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from email.mime.image import MIMEImage
+from email.mime.audio import MIMEAudio
+from email.mime.multipart import MIMEMultipart
 from html2text import html2text
 import json
 import os
@@ -14,6 +16,7 @@ import subprocess as sub
 import sys
 import time
 import glob
+import mimetypes
 
 from inlinestyler.utils import inline_css
 from jinja2 import Template
@@ -84,11 +87,42 @@ def add_attachments(src, message, payload):
 
 
 def get_attachment(src, file_name):
-    attachment = MIMEBase('application', 'octet-stream')
-    with open(os.path.join(src, file_name)) as fp:
+
+    file_name_path = os.path.join(src, file_name)
+    ctype, encoding = mimetypes.guess_type(file_name_path)
+
+    if ctype is None or encoding is not None:
+        # no guess could be made, or the file is encoded (compressed), so use a generic bag-of-bits type.
+        ctype = 'application/octet-stream'
+
+    maintype, subtype = ctype.split('/', 1)
+
+    if maintype == 'text':
+        fp = open(file_name_path)
+        # note: we should handle calculating the charset
+        attachment = MIMEText(fp.read(), _subtype=subtype)
+        fp.close()
+
+    elif maintype == 'image':
+        fp = open(file_name_path, 'rb')
+        attachment = MIMEImage(fp.read(), _subtype=subtype)
+        fp.close()
+
+    elif maintype == 'audio':
+        fp = open(file_name_path, 'rb')
+        attachment = MIMEAudio(fp.read(), _subtype=subtype)
+        fp.close()
+
+    else:
+        fp = open(file_name_path, 'rb')
+        attachment = MIMEBase(maintype, subtype)
         attachment.set_payload(fp.read())
-    encoders.encode_base64(attachment)
+        fp.close()
+        # encode the payload using Base64
+        encoders.encode_base64(attachment)
+
     attachment.add_header('Content-Disposition', 'attachment', filename=os.path.basename(file_name))
+
     return attachment
 
 

--- a/opt/resource/out
+++ b/opt/resource/out
@@ -13,6 +13,7 @@ from smtplib import SMTP
 import subprocess as sub
 import sys
 import time
+import glob
 
 from inlinestyler.utils import inline_css
 from jinja2 import Template
@@ -73,9 +74,13 @@ def get_recipients(src, payload):
 
 
 def add_attachments(src, message, payload):
-    file_names = get_value_from_payload(payload, 'params', 'attachments', default=[], optional=True)
-    for file_name in file_names:
-        message.attach(get_attachment(src, file_name))
+    attachments = get_value_from_payload(payload, 'params', 'attachments', default=[], optional=True)
+    for path in attachments:
+        if '*' in path:
+            for file_name in glob.glob(os.path.join(src, path)):
+                message.attach(get_attachment(src, file_name))
+        else:
+            message.attach(get_attachment(src, path))
 
 
 def get_attachment(src, file_name):
@@ -83,7 +88,7 @@ def get_attachment(src, file_name):
     with open(os.path.join(src, file_name)) as fp:
         attachment.set_payload(fp.read())
     encoders.encode_base64(attachment)
-    attachment.add_header('Content-Disposition', 'attachment', filename=file_name)
+    attachment.add_header('Content-Disposition', 'attachment', filename=os.path.basename(file_name))
     return attachment
 
 


### PR DESCRIPTION
🍭 This contribution adds support to attachment wildcards (as seen in resources like *artifactory-resource*), example:

```
      - put: send-mail-notification
        params:
          to:
            - eric.cartman@foobar.com
            - stan.marsh@foobar.com
            - butters.stotch@foobar.com
          subject: mail/subject.txt
          body: mail/body.txt
          attachments:
            - build_results/build-id-*.tar.gz
```

*I know... I know...* who on earth sends build results via e-mail?

Anyway, you get the point. This is particularly useful for files with versions (or whatever kind of dynamic tag) in its filename.

**PS: There is also a small fix for the attachment filenames seen in the recipient mailbox.**